### PR TITLE
REP-6592 Incremental builds take two

### DIFF
--- a/src/main/groovy/org/openrepose/gradle/plugins/jaxb/JaxbPlugin.groovy
+++ b/src/main/groovy/org/openrepose/gradle/plugins/jaxb/JaxbPlugin.groovy
@@ -148,6 +148,9 @@ class JaxbPlugin implements Plugin<Project> {
       "and find all unique namespaces, create a namespace graph and parse in " +
       "the graph order with jaxb"
     jnt.group = JAXB_TASK_GROUP
+    jnt.conventionMapping.generatedFilesDirectory = {
+      new File((String)project.jaxb.xjc.destinationDir)
+    }
     jnt.conventionMapping.xsds = {
       project.fileTree(
               dir: new File((String)project.jaxb.xsdDir),

--- a/src/main/groovy/org/openrepose/gradle/plugins/jaxb/task/JaxbDependencyTree.groovy
+++ b/src/main/groovy/org/openrepose/gradle/plugins/jaxb/task/JaxbDependencyTree.groovy
@@ -2,6 +2,7 @@ package org.openrepose.gradle.plugins.jaxb.task
 
 import org.gradle.api.logging.Logging
 import org.gradle.api.logging.Logger
+import org.gradle.api.tasks.OutputDirectory
 import org.gradle.api.tasks.TaskAction
 import org.gradle.api.tasks.InputFiles
 import org.gradle.api.file.FileCollection
@@ -17,7 +18,16 @@ import org.openrepose.gradle.plugins.jaxb.schema.factory.DocumentFactory
 class JaxbDependencyTree extends DefaultTask { 
   
   static final Logger log = Logging.getLogger(JaxbDependencyTree.class)
-  
+
+  /**
+   * Directory where the generated java files from xjc would go
+   * Usually {@code <project-root>/build/generated-sources/xjc}
+   *
+   * NOTE: This is only used for the UP-TO-DATE check.
+   */
+  @OutputDirectory
+  File generatedFilesDirectory
+
   /**
    * Xsd's under defined {@code xsdDir}.
    */


### PR DESCRIPTION
This is a hack since the Dependency Tree doesn't actually create anything, so we use the output of the next task to see if it is up to date. If it is, then obviously this doesn't need to run either.